### PR TITLE
add querying by topic to GET /api/articles

### DIFF
--- a/__tests__/articles.tests.js
+++ b/__tests__/articles.tests.js
@@ -17,7 +17,7 @@ describe('GET /api/articles', () => {
         const { body } = await request(app)
         .get('/api/articles')
         .expect(200)
-        body.forEach((article) => {
+        body.articles.forEach((article) => {
             expect(article).toMatchObject({
                 author: expect.any(String),
                 title: expect.any(String),
@@ -34,11 +34,56 @@ describe('GET /api/articles', () => {
         const { body } = await request(app)
         .get('/api/articles')
         .expect(200)
-        body.forEach((article) => {
+        body.articles.forEach((article) => {
             if (article.article_id === 2) {
                 expect(article.comment_count).toBe(0)
             }
         })
+    });
+});
+
+describe('GET /api/articles?query=aQuery', () => {
+    it('should get queries by topic', async () => {
+        const { body } = await request(app)
+        .get('/api/articles?topic=cats')
+        .expect(200)
+        expect(body.articles.length).toBe(1)
+        body.articles.forEach((article) => {
+            expect(article).toMatchObject({
+                author: expect.any(String),
+                title: expect.any(String),
+                article_id: expect.any(Number),
+                topic: 'cats',
+                created_at: expect.any(String),
+                votes: expect.any(Number),
+                article_img_url: expect.any(String),
+                comment_count: expect.any(Number)
+            })
+        })
+    });
+    it('should return all articles if no topic is provided', async () => {
+        const { body } = await request(app)
+        .get('/api/articles')
+        .expect(200)
+        expect(body.articles.length).toBe(13)
+        body.articles.forEach((article) => {
+            expect(article).toMatchObject({
+                author: expect.any(String),
+                title: expect.any(String),
+                article_id: expect.any(Number),
+                topic: expect.any(String),
+                created_at: expect.any(String),
+                votes: expect.any(Number),
+                article_img_url: expect.any(String),
+                comment_count: expect.any(Number)
+            })
+        })
+    });
+    it('should return an empty list if the topic does not exist', async () => {
+        const { body } = await request(app)
+        .get('/api/articles?topic=somethingWitty')
+        .expect(200)
+        expect(body.articles.length).toBe(0)
     });
 });
 

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -2,9 +2,11 @@ const { fetchArticles, fetchArticleById, updateArticle } = require('../models/ar
 
 exports.getArticles = async (req, res, next) => {
     try {
-        const fetchedArticles = await fetchArticles()
+        const { topic } = req.query
+        const fetchedArticles = await fetchArticles(topic)
         res.status(200).send(fetchedArticles)
     } catch(error) {
+        console.log(error)
         next(error)
     }
 }

--- a/endpoints.json
+++ b/endpoints.json
@@ -19,7 +19,7 @@
   },
   "GET /api/articles": {
     "description": "serves an array of all articles",
-    "queries": ["author", "topic", "sort_by", "order"],
+    "queries": ["topic"],
     "exampleResponse": {
       "articles": [
         {


### PR DESCRIPTION
1. Add ability to query by topic to GET /api/articles
2. Add tests for the above
3. Update endpoints.json so the supported queries shows only querying by topic is supported